### PR TITLE
feat: Add namespace and task filtering with PDF page breaks per namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,12 +337,17 @@ To generate a usage report and export it to a specified S3 bucket, provide the f
 | --database-workgroup-name       | Name of Athena's workgroup          | `usage_report_workgroup`   | Yes      |
 | --type                | Type of report to generate             | `detailed` or `summary`        | Yes      |
 | --output-report-location | Directory where report will be saved | `s3://bucket-name/path` | Yes      |
-| --cluster-name        | Name of the HyperPod cluster           | `my-hyperpod-cluster` | Yes      |
+| `--cluster-name` | Name of the HyperPod cluster | `my-hyperpod-cluster` | Yes |
+| `--namespace` | Filter report by namespace (optional) | `ml-namespace-a` | No |
+| `--task` | Filter report by task name (optional) | `training-job-1` | No |
 
-**Note:** 
+**Note:**
 - Select a date range that falls within the previous 180 days from the current date (unless you customized the `DataRententionDays` when installing the CloudFormation stack).
 
 - A good practice is to create a separate folder in your S3 bucket to serve as the destination for generated usage reports.
+
+- The `--namespace` parameter allows you to filter reports to show only data for a specific namespace. If not specified, the report will include data for all namespaces.
+- The `--task` parameter allows you to filter reports to show only data for a specific task. If not specified, the report will include data for all tasks.
 
 Use the following command to generate and export the report:
 ```sh
@@ -354,18 +359,98 @@ python run.py \
 --database-workgroup-name $DATABASE_WORKGROUP_NAME \
 --type <detailed or summary> \
 --output-report-location s3://$USAGE_REPORT_S3_BUCKET/<usage report output folder> \
---cluster-name $HYPERPOD_CLUSTER_NAME
+--cluster-name $HYPERPOD_CLUSTER_NAME \
+--namespace <namespace, optional> \
+--task <task name, optional>
 ```
 **Note**
 * Ensure that the S3 bucket specified in `--output-report-location` has the necessary permissions to accept the report files.
 * The `cluster-name` should match the name of your SageMaker HyperPod cluster.
-* You can find all original captured data in the `raw` directory of your S3 bucket `$USAGE_REPORT_S3_BUCKET/raw` or in the Athena console.</para>
+* You can find all original captured data in the `raw` directory of your S3 bucket `$USAGE_REPORT_S3_BUCKET/raw` or in the Athena console.
+
+### Usage Examples
+
+#### Generate a report for all namespaces (default behavior)
+```sh
+python run.py \
+--start-date 2025-04-15 \
+--end-date 2025-04-17 \
+--format csv \
+--database-name $USAGE_REPORT_DATABASE \
+--database-workgroup-name $DATABASE_WORKGROUP_NAME \
+--type summary \
+--output-report-location s3://$USAGE_REPORT_S3_BUCKET/reports/ \
+--cluster-name $HYPERPOD_CLUSTER_NAME
+```
+
+#### Generate a report filtered by namespace
+```sh
+python run.py \
+--start-date 2025-04-15 \
+--end-date 2025-04-17 \
+--format pdf \
+--database-name $USAGE_REPORT_DATABASE \
+--database-workgroup-name $DATABASE_WORKGROUP_NAME \
+--type detailed \
+--output-report-location s3://$USAGE_REPORT_S3_BUCKET/reports/ \
+--cluster-name $HYPERPOD_CLUSTER_NAME \
+--namespace ml-namespace-a
+```
+
+#### Generate a summary report for a specific namespace
+```sh
+python run.py \
+--start-date 2025-04-15 \
+--end-date 2025-04-17 \
+--format csv \
+--database-name $USAGE_REPORT_DATABASE \
+--database-workgroup-name $DATABASE_WORKGROUP_NAME \
+--type summary \
+--output-report-location s3://$USAGE_REPORT_S3_BUCKET/reports/ \
+--cluster-name $HYPERPOD_CLUSTER_NAME \
+--namespace data-science-namespace
+```
+
+#### Generate a report for a specific task
+```sh
+python run.py \
+--start-date 2025-04-15 \
+--end-date 2025-04-17 \
+--format csv \
+--database-name $USAGE_REPORT_DATABASE \
+--database-workgroup-name $DATABASE_WORKGROUP_NAME \
+--type summary \
+--output-report-location s3://$USAGE_REPORT_S3_BUCKET/reports/ \
+--cluster-name $HYPERPOD_CLUSTER_NAME \
+--task training-job-1
+```
+
+#### Generate a report for a specific namespace and task
+```sh
+python run.py \
+--start-date 2025-04-15 \
+--end-date 2025-04-17 \
+--format pdf \
+--database-name $USAGE_REPORT_DATABASE \
+--database-workgroup-name $DATABASE_WORKGROUP_NAME \
+--type detailed \
+--output-report-location s3://$USAGE_REPORT_S3_BUCKET/reports/ \
+--cluster-name $HYPERPOD_CLUSTER_NAME \
+--namespace ml-namespace-a \
+--task inference-job-2
+```
 
 
 ### Output File Naming Convention
 The output file follows the naming convention: `<report-type>-report-<start-date>-<end-date>.<format>`.
 
-For example, a summary report for the dates April 15, 2025, to April 17, 2025, in CSV format will be named `summary-report-2025-04-15-2025-04-17.csv` and will be located in the specified output directory `--output-report-location` of your S3 bucket.
+When filters are applied, the filename includes the filter names after the date range: `<report-type>-report-<start-date>-<end-date>-<namespace>-<task>.<format>`.
+
+**Examples:**
+- Summary report for all namespaces: `summary-report-2025-04-15-2025-04-17.csv`
+- Summary report for ML Namespace A: `summary-report-2025-04-15-2025-04-17-ml-namespace-a.csv`
+- Detailed report for Data Science Namespace: `detailed-report-2025-04-15-2025-04-17-data-science-namespace.pdf`
+- Report for specific namespace and task: `summary-report-2025-04-15-2025-04-17-ml-namespace-a-training-job-1.csv`
 
 
 ## Clean Up Resources

--- a/report_generation/run.py
+++ b/report_generation/run.py
@@ -39,6 +39,8 @@ def main():
         help="S3 location for output (s3://bucket/path)",
     )
     parser.add_argument("--cluster-name", required=True, help="Hyperpod Cluster Name")
+    parser.add_argument("--namespace", required=False, help="Filter report by namespace (optional)")
+    parser.add_argument("--task", required=False, help="Filter report by task name (optional)")
     
     args = parser.parse_args()
 
@@ -51,6 +53,8 @@ def main():
         report_type=args.type,
         output_location=args.output_report_location,
         format=args.format,
+        namespace=args.namespace,
+        task=args.task,
     )
 
     generator.generate_report()

--- a/report_generation/src/hyperpod_usage_report/generators/base.py
+++ b/report_generation/src/hyperpod_usage_report/generators/base.py
@@ -5,6 +5,10 @@ import pandas as pd
 
 class BaseReportGenerator(ABC):
     """Base class for report generators"""
+    
+    # File extensions
+    CSV_EXTENSION = "csv"
+    PDF_EXTENSION = "pdf"
 
     @abstractmethod
     def generate_summary_report(
@@ -19,3 +23,14 @@ class BaseReportGenerator(ABC):
     ) -> str:
         """Generate detailed report in specific format"""
         pass
+
+    def _build_filename(self, header_info: dict, extension: str) -> str:
+        """Build filename with optional namespace and task suffixes"""
+        namespace_suffix = f"-{header_info['namespace']}" if header_info.get('namespace') else ""
+        task_suffix = f"-{header_info['task']}" if header_info.get('task') else ""
+        base_name = f"{header_info['report_type']}-report-{header_info['start_date']}"
+        return (
+            f"{base_name}-{header_info['end_date']}{namespace_suffix}{task_suffix}.{extension}"
+            if int(header_info["days"]) > 1
+            else f"{base_name}{namespace_suffix}{task_suffix}.{extension}"
+        )

--- a/report_generation/src/hyperpod_usage_report/utils/query_builder.py
+++ b/report_generation/src/hyperpod_usage_report/utils/query_builder.py
@@ -1,22 +1,28 @@
 class QueryBuilder:
     @staticmethod
     def build_fetch_report_data_query(
-        report_type: str, start_date: str, end_date: str
+        report_type: str, start_date: str, end_date: str, namespace: str = None, task: str = None
     ) -> str:
+        where_clause = f"DATE(report_date) BETWEEN DATE('{start_date}') AND DATE('{end_date}')"
+        
+        if namespace:
+            where_clause += f" AND namespace = '{namespace}'"
+        
+        if task:
+            where_clause += f" AND task_name = '{task}'"
+        
         if report_type == "summary":
             return f"""
             SELECT *
             FROM summary_report
-            WHERE DATE(report_date) BETWEEN DATE('{start_date}')
-                AND DATE('{end_date}')
+            WHERE {where_clause}
             ORDER BY report_date, namespace, team
             """
         elif report_type == "detailed":
             return f"""
             SELECT *
             FROM detailed_report
-            WHERE DATE(report_date) BETWEEN DATE('{start_date}')
-                AND DATE('{end_date}')
+            WHERE {where_clause}
             ORDER BY report_date, period_start, namespace, team, task_name
             """
         else:

--- a/report_generation/test/unit/test_report_generator.py
+++ b/report_generation/test/unit/test_report_generator.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from unittest.mock import Mock, patch
 
 import pytest
+import pandas as pd
 
 from src.hyperpod_usage_report.report_generator import ReportGenerator
 
@@ -51,3 +52,287 @@ def test_fetch_data_error(mock_wr, report_generator):
     with pytest.raises(Exception) as exc_info:
         report_generator._fetch_data()
     assert "Database error" in str(exc_info.value)
+
+
+def test_report_generator_init_with_team():
+    # Arrange
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+    output_location = "s3://test-bucket/reports/"
+    database_workgroup_name = "test-workgroup"
+    format = "csv"
+    database_name = "test-database"
+    report_type = "summary"
+    cluster_name = "test-cluster"
+    namespace = "test-namespace"
+
+    # Act
+    generator = ReportGenerator(
+        start_date=start_date,
+        end_date=end_date,
+        output_location=output_location,
+        database_workgroup_name=database_workgroup_name,
+        format=format,
+        database_name=database_name,
+        report_type=report_type,
+        cluster_name=cluster_name,
+        namespace=namespace,
+    )
+
+    # Assert
+    assert generator.namespace == namespace
+
+
+def test_report_generator_init_without_team():
+    # Arrange & Act
+    generator = ReportGenerator(
+        start_date="2025-03-25",
+        end_date="2025-03-25",
+        cluster_name="dummy-cluster",
+        database_name="dummy-db",
+        database_workgroup_name='dummy-workgroup',
+        report_type="summary",
+        output_location="s3://dummy-bucket/reports",
+        format="csv",
+    )
+    
+    # Assert
+    assert generator.namespace is None
+
+
+def test_prepare_header_info_with_team():
+    # Arrange
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+    output_location = "s3://test-bucket/reports/"
+    database_workgroup_name = "test-workgroup"
+    format = "csv"
+    database_name = "test-database"
+    report_type = "summary"
+    cluster_name = "test-cluster"
+    namespace = "ml-team"
+
+    generator = ReportGenerator(
+        start_date=start_date,
+        end_date=end_date,
+        output_location=output_location,
+        database_workgroup_name=database_workgroup_name,
+        format=format,
+        database_name=database_name,
+        report_type=report_type,
+        cluster_name=cluster_name,
+        namespace=namespace,
+    )
+
+    # Act
+    header_info = generator._prepare_header_info()
+
+    # Assert
+    assert header_info["namespace"] == "ml-team"
+
+
+def test_prepare_header_info_without_team():
+    # Arrange
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+    output_location = "s3://test-bucket/reports/"
+    database_workgroup_name = "test-workgroup"
+    format = "csv"
+    database_name = "test-database"
+    report_type = "summary"
+    cluster_name = "test-cluster"
+    namespace = None
+
+    generator = ReportGenerator(
+        start_date=start_date,
+        end_date=end_date,
+        output_location=output_location,
+        database_workgroup_name=database_workgroup_name,
+        format=format,
+        database_name=database_name,
+        report_type=report_type,
+        cluster_name=cluster_name,
+        namespace=namespace,
+    )
+
+    # Act
+    header_info = generator._prepare_header_info()
+
+    # Assert
+    assert "namespace" not in header_info
+
+
+def test_prepare_header_info_with_task():
+    # Arrange
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+    output_location = "s3://test-bucket/reports/"
+    database_workgroup_name = "test-workgroup"
+    format = "csv"
+    database_name = "test-database"
+    report_type = "summary"
+    cluster_name = "test-cluster"
+    namespace = "ml-team"
+    task = "training-job-1"
+
+    generator = ReportGenerator(
+        start_date=start_date,
+        end_date=end_date,
+        output_location=output_location,
+        database_workgroup_name=database_workgroup_name,
+        format=format,
+        database_name=database_name,
+        report_type=report_type,
+        cluster_name=cluster_name,
+        namespace=namespace,
+        task=task,
+    )
+
+    # Act
+    header_info = generator._prepare_header_info()
+
+    # Assert
+    assert header_info["namespace"] == "ml-team"
+    assert header_info["task"] == "training-job-1"
+
+
+@patch("src.hyperpod_usage_report.report_generator.wr")
+@patch("src.hyperpod_usage_report.report_generator.QueryBuilder")
+def test_fetch_data_with_team(mock_query_builder, mock_wr):
+    # Arrange
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+    output_location = "s3://test-bucket/reports/"
+    database_workgroup_name = "test-workgroup"
+    format = "csv"
+    database_name = "test-database"
+    report_type = "summary"
+    cluster_name = "test-cluster"
+    namespace = "data-science"
+
+    generator = ReportGenerator(
+        start_date=start_date,
+        end_date=end_date,
+        output_location=output_location,
+        database_workgroup_name=database_workgroup_name,
+        format=format,
+        database_name=database_name,
+        report_type=report_type,
+        cluster_name=cluster_name,
+        namespace=namespace,
+    )
+
+    mock_df = pd.DataFrame({"test": [1, 2, 3]})
+    mock_wr.athena.read_sql_query.return_value = mock_df
+
+    # Act
+    result = generator._fetch_data()
+
+    # Assert
+    mock_query_builder.build_fetch_report_data_query.assert_called_once_with(
+        "summary", "2025-03-25", "2025-03-25", "data-science", None
+    )
+    pd.testing.assert_frame_equal(result, mock_df)
+
+
+@patch("src.hyperpod_usage_report.report_generator.wr")
+@patch("src.hyperpod_usage_report.report_generator.QueryBuilder")
+def test_fetch_data_without_team(mock_query_builder, mock_wr):
+    # Arrange
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+    output_location = "s3://test-bucket/reports/"
+    database_workgroup_name = "test-workgroup"
+    format = "csv"
+    database_name = "test-database"
+    report_type = "summary"
+    cluster_name = "test-cluster"
+    namespace = None
+
+    generator = ReportGenerator(
+        start_date=start_date,
+        end_date=end_date,
+        output_location=output_location,
+        database_workgroup_name=database_workgroup_name,
+        format=format,
+        database_name=database_name,
+        report_type=report_type,
+        cluster_name=cluster_name,
+        namespace=namespace,
+    )
+
+    mock_df = pd.DataFrame({"test": [1, 2, 3]})
+    mock_wr.athena.read_sql_query.return_value = mock_df
+
+    # Act
+    result = generator._fetch_data()
+
+    # Assert
+    mock_query_builder.build_fetch_report_data_query.assert_called_once_with(
+        "summary", "2025-03-25", "2025-03-25", None, None
+    )
+    pd.testing.assert_frame_equal(result, mock_df)
+
+
+def test_report_generator_init_without_team():
+    # Arrange
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+    output_location = "s3://test-bucket/reports/"
+    database_workgroup_name = "test-workgroup"
+    format = "csv"
+    database_name = "test-database"
+    report_type = "summary"
+    cluster_name = "test-cluster"
+    namespace = None
+    task = None
+
+    # Act
+    generator = ReportGenerator(
+        start_date=start_date,
+        end_date=end_date,
+        output_location=output_location,
+        database_workgroup_name=database_workgroup_name,
+        format=format,
+        database_name=database_name,
+        report_type=report_type,
+        cluster_name=cluster_name,
+        namespace=namespace,
+        task=task,
+    )
+
+    # Assert
+    assert generator.namespace is None
+    assert generator.task is None
+
+
+def test_report_generator_init_with_task():
+    # Arrange
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+    output_location = "s3://test-bucket/reports/"
+    database_workgroup_name = "test-workgroup"
+    format = "csv"
+    database_name = "test-database"
+    report_type = "summary"
+    cluster_name = "test-cluster"
+    namespace = "ml-team"
+    task = "training-job-1"
+
+    # Act
+    generator = ReportGenerator(
+        start_date=start_date,
+        end_date=end_date,
+        output_location=output_location,
+        database_workgroup_name=database_workgroup_name,
+        format=format,
+        database_name=database_name,
+        report_type=report_type,
+        cluster_name=cluster_name,
+        namespace=namespace,
+        task=task,
+    )
+
+    # Assert
+    assert generator.namespace == "ml-team"
+    assert generator.task == "training-job-1"

--- a/report_generation/test/unit/utils/test_query_builder.py
+++ b/report_generation/test/unit/utils/test_query_builder.py
@@ -78,3 +78,160 @@ def test_build_fetch_heartdub_query_different_dates():
     assert f"DATE('{start_date}')" in query
     assert f"DATE('{end_date}')" in query
     assert "BETWEEN" in query
+
+
+def test_build_query_summary_with_team():
+    # Arrange
+    report_type = "summary"
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+    namespace = "test-namespace"
+
+    # Act
+    query = QueryBuilder.build_fetch_report_data_query(
+        report_type, start_date, end_date, namespace
+    )
+
+    # Assert
+    assert "WHERE DATE(report_date) BETWEEN DATE('2025-03-25') AND DATE('2025-03-25')" in query
+    assert f"AND namespace = '{namespace}'" in query
+
+
+def test_build_query_detailed_with_team():
+    # Arrange
+    report_type = "detailed"
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+    namespace = "data-science"
+
+    # Act
+    query = QueryBuilder.build_fetch_report_data_query(
+        report_type, start_date, end_date, namespace
+    )
+
+    # Assert
+    assert "WHERE DATE(report_date) BETWEEN DATE('2025-03-25') AND DATE('2025-03-25')" in query
+    assert f"AND namespace = '{namespace}'" in query
+
+
+def test_build_query_summary_without_team():
+    # Arrange
+    report_type = "summary"
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+
+    # Act
+    query = QueryBuilder.build_fetch_report_data_query(
+        report_type, start_date, end_date, namespace=None
+    )
+
+    # Assert
+    assert "WHERE DATE(report_date) BETWEEN DATE('2025-03-25') AND DATE('2025-03-25')" in query
+    assert "AND namespace =" not in query
+
+
+def test_build_query_detailed_without_team():
+    # Arrange
+    report_type = "detailed"
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+
+    # Act
+    query = QueryBuilder.build_fetch_report_data_query(
+        report_type, start_date, end_date, namespace=None
+    )
+
+    # Assert
+    assert "WHERE DATE(report_date) BETWEEN DATE('2025-03-25') AND DATE('2025-03-25')" in query
+    assert "AND namespace =" not in query
+
+
+def test_build_query_with_empty_team():
+    # Arrange
+    report_type = "summary"
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+    namespace = ""
+
+    # Act
+    query = QueryBuilder.build_fetch_report_data_query(
+        report_type, start_date, end_date, namespace
+    )
+
+    # Assert
+    assert "WHERE DATE(report_date) BETWEEN DATE('2025-03-25') AND DATE('2025-03-25')" in query
+    assert "AND namespace =" not in query
+
+
+def test_build_query_with_team_containing_quotes():
+    # Arrange
+    report_type = "summary"
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+    namespace = "ml-team"
+
+    # Act
+    query = QueryBuilder.build_fetch_report_data_query(
+        report_type, start_date, end_date, namespace
+    )
+
+    # Assert
+    assert "WHERE DATE(report_date) BETWEEN DATE('2025-03-25') AND DATE('2025-03-25')" in query
+    assert f"AND namespace = '{namespace}'" in query
+
+
+def test_build_query_with_task_containing_quotes():
+    # Arrange
+    report_type = "summary"
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+    namespace = "ml-team"
+    task = "training-job-1"
+
+    # Act
+    query = QueryBuilder.build_fetch_report_data_query(
+        report_type, start_date, end_date, namespace, task
+    )
+
+    # Assert
+    assert "WHERE DATE(report_date) BETWEEN DATE('2025-03-25') AND DATE('2025-03-25')" in query
+    assert "AND namespace = 'ml-team'" in query
+    assert "AND task_name = 'training-job-1'" in query
+
+
+def test_build_query_with_task_only():
+    # Arrange
+    report_type = "detailed"
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+    namespace = None
+    task = "inference-job-2"
+
+    # Act
+    query = QueryBuilder.build_fetch_report_data_query(
+        report_type, start_date, end_date, namespace, task
+    )
+
+    # Assert
+    assert "WHERE DATE(report_date) BETWEEN DATE('2025-03-25') AND DATE('2025-03-25')" in query
+    assert "AND namespace =" not in query
+    assert "AND task_name = 'inference-job-2'" in query
+
+
+def test_build_query_with_team_and_task():
+    # Arrange
+    report_type = "summary"
+    start_date = "2025-03-25"
+    end_date = "2025-03-25"
+    namespace = "data-science"
+    task = "model-training"
+
+    # Act
+    query = QueryBuilder.build_fetch_report_data_query(
+        report_type, start_date, end_date, namespace, task
+    )
+
+    # Assert
+    assert "WHERE DATE(report_date) BETWEEN DATE('2025-03-25') AND DATE('2025-03-25')" in query
+    assert "AND namespace = 'data-science'" in query
+    assert "AND task_name = 'model-training'" in query


### PR DESCRIPTION
## Summary
Adds namespace and task filtering capabilities to usage reports with --namespace and --task parameters, plus PDF page breaks by namespace for better organization.

## Changes
- Add --namespace parameter to filter reports by team name
- Add --task parameter to filter reports by task name
- Implement PDF page breaks: each namepace data appears on a separate page
- Update README.md to include description of changes
- Add unit tests and documentation

## Testing
- All unit tests pass
- Verified CSV and PDF generation with different filters

## Backward Compatibility
- Existing functionality unchanged when `--namespace` and `--task` are not specified
- All existing commands continue to work as before