### PR TITLE
Pin PyArrow version to fix Python version conflict

### DIFF
--- a/report_generation/setup.py
+++ b/report_generation/setup.py
@@ -9,6 +9,7 @@ setup(
         "boto3>=1.26.0",
         "pandas>=1.5.0",
         "awswrangler>=3.0.0",
+        "pyarrow==20.0.0",
         "fpdf>=1.7.2",
     ],
     python_requires=">=3.8",


### PR DESCRIPTION
*Issue #, if available:*
There is a support issue between Python 3.9 and the downstream PyArrow dependency version.   
*Description of changes:*
This change pins the PyArrow version to one supported by Python 3.9. Tests pass in alpha and reports are confirmed created. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
